### PR TITLE
fix(EmbeddedGraphQLEditor): wrap EmbeddedEditor in ToastsProvider

### DIFF
--- a/packages/editor/src/editor/index.tsx
+++ b/packages/editor/src/editor/index.tsx
@@ -69,7 +69,9 @@ export const EmbeddedGraphQLEditor = ({ ...props }: EmbeddedEditorProps) => {
                 <LayoutStateProvider>
                   <RelationNodesProvider>
                     <ScThemeProvider theme={theme}>
-                      <EmbeddedEditor {...props} />
+                      <ToastsProvider>
+                        <EmbeddedEditor {...props} />
+                      </ToastsProvider>
                     </ScThemeProvider>
                   </RelationNodesProvider>
                 </LayoutStateProvider>


### PR DESCRIPTION
## Description

It is necessary to wrap `EmbeddedEditor` within the `ToastsProvider` to avoid Toasts context errors:
![image](https://github.com/graphql-editor/graphql-editor/assets/13089934/b4126fb4-4fc2-466e-addc-0a3a69ba6818)


This PR addresses https://github.com/graphql-editor/graphql-editor/issues/562.

