### PR TITLE
Scroll import schema headers

### DIFF
--- a/packages/editor/src/shared/dialogs/ImportSchema.tsx
+++ b/packages/editor/src/shared/dialogs/ImportSchema.tsx
@@ -207,7 +207,10 @@ export const ImportSchema: React.FC<{
           />
           <Typography variant="caption">Headers</Typography>
         </Stack>
-        <Stack direction="column">
+        <Stack
+          direction="column"
+          css={{ maxHeight: "22rem", overflow: "auto", marginBottom: "1rem" }}
+        >
           {headers.map(([k, v], i) => (
             <Stack key={i} gap="1rem">
               <TextField


### PR DESCRIPTION
https://scroll-import-schema-headers.graphql-editor-dev.pages.dev/

przydałby się scroll do ostatniego elementu po dodaniu (do tego do dodawania) ale to chyba trzeba by było dać możliwość dodawania ref do elementu stack w styling system bo teraz nie widzę takiej możliwości