### PR TITLE
Font as theme prop

### DIFF
--- a/packages/editor/src/DiffEditor/index.tsx
+++ b/packages/editor/src/DiffEditor/index.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled";
 import React, { useState } from "react";
 import { Parser, TreeToGraphQL } from "graphql-js-tree";
 import { useSortState } from "@/state/containers/sort";
-import { fontFamilySans } from "@/vars";
 import { Arrow_AZ, Stack, Typography } from "@aexol-studio/styling-system";
 
 interface DiffEditorProps {
@@ -32,7 +31,7 @@ const Heading = styled.h1`
   font-size: 14px;
   font-weight: 500;
   color: ${({ theme }) => theme.text.disabled};
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
 `;
 
 const AZContainer = styled.div<{ active?: boolean }>`

--- a/packages/editor/src/Docs/Description.tsx
+++ b/packages/editor/src/Docs/Description.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
-import { fontFamilySans } from "@/vars";
 
 const Main = styled.textarea`
   background: ${({ theme }) => theme.neutral[600]};
@@ -12,7 +11,7 @@ const Main = styled.textarea`
   resize: none;
   outline: none;
   cursor: pointer;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   &:focus {
     cursor: auto;
   }

--- a/packages/editor/src/Docs/DocsElement.tsx
+++ b/packages/editor/src/Docs/DocsElement.tsx
@@ -1,7 +1,6 @@
 import { FieldsList } from "@/Docs/FieldsList";
 import { InterfacesList } from "@/Docs/InterfacesList";
 import { useTreesState } from "@/state/containers";
-import { fontFamilySans } from "@/vars";
 import { ParserField, getTypeName, compareParserFields } from "graphql-js-tree";
 import React, { useMemo, useState } from "react";
 import { Remarkable } from "remarkable";
@@ -11,7 +10,7 @@ import { Description } from "@/Docs/Description";
 import { PenLine } from "@aexol-studio/styling-system";
 
 const Wrapper = styled.div`
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-size: 14px;
   padding: 40px 50px;
   max-width: 960px;

--- a/packages/editor/src/Docs/InterfacesList.tsx
+++ b/packages/editor/src/Docs/InterfacesList.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { fontFamilySans, transition } from '@/vars';
-import styled from '@emotion/styled';
+import React from "react";
+import { transition } from "@/vars";
+import styled from "@emotion/styled";
 
 const Interface = styled.p`
   color: ${({ theme }) => theme.colors.interface};
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-size: 14px;
   padding: 4px 12px;
   margin: 0;
@@ -28,7 +28,7 @@ const InterfacesWrapper = styled.div`
 
 const Title = styled.h3`
   color: ${({ theme }) => theme.text.disabled};
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-size: 18px;
 `;
 

--- a/packages/editor/src/Graf/Graf.tsx
+++ b/packages/editor/src/Graf/Graf.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useCallback } from "react";
-import { fontFamilySans } from "@/vars";
 import { ActiveNode } from "@/Graf/Node";
 import { useTreesState } from "@/state/containers/trees";
 
@@ -21,7 +20,7 @@ import { motion } from "framer-motion";
 import { isEditableParentField } from "@/utils";
 
 const SubNodeContainer = styled.div`
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   transition: max-width 0.5s ease-in-out;
   max-width: 80%;
   bottom: 0;

--- a/packages/editor/src/Graf/Node/Field/EditableText/index.tsx
+++ b/packages/editor/src/Graf/Node/Field/EditableText/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from "react";
-import { fontFamilySans } from "@/vars";
 import styled from "@emotion/styled";
 import { GRAF_FIELD_NAME_SIZE } from "@/Graf/constants";
 import { useDraggable } from "@/Graf/state/draggable";
@@ -10,7 +9,7 @@ const Input = styled.input<{ isError?: boolean; isEditable?: boolean }>`
   background-color: transparent;
   min-width: auto;
   padding: 0;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-size: ${GRAF_FIELD_NAME_SIZE}px;
   color: inherit;
 `;
@@ -110,7 +109,7 @@ export const EditableText: React.FC<{
 const HiddenSpan = styled.span`
   visibility: hidden;
   padding: 0;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   left: 0;
   position: absolute;
   pointer-events: none;

--- a/packages/editor/src/Graf/Node/components/Description/ActiveDescription.tsx
+++ b/packages/editor/src/Graf/Node/components/Description/ActiveDescription.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
-import styled from '@emotion/styled';
-import { fontFamilySans } from '@/vars';
+import React, { useEffect, useRef, useState } from "react";
+import styled from "@emotion/styled";
 
 const Main = styled.textarea`
   background: ${({ theme }) => theme.neutral[600]};
@@ -13,7 +12,7 @@ const Main = styled.textarea`
   cursor: pointer;
   border-top-left-radius: 0.5rem;
   border-top-right-radius: 0.5rem;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-size: 14px;
   &:focus {
     cursor: auto;
@@ -63,11 +62,11 @@ export const ActiveDescription: React.FC<{
         onClick={(e) => e.stopPropagation()}
         onMouseMove={(e) => e.stopPropagation()}
         onFocus={(e) => {
-          e.currentTarget.style.height = 'auto';
-          e.currentTarget.style.height = e.currentTarget.scrollHeight + 'px';
+          e.currentTarget.style.height = "auto";
+          e.currentTarget.style.height = e.currentTarget.scrollHeight + "px";
         }}
         onBlur={(e) => {
-          e.currentTarget.style.height = 'auto';
+          e.currentTarget.style.height = "auto";
           if (isLocked) return;
           if (DescriptionRef.current) {
             currentRef.current = text;
@@ -78,8 +77,8 @@ export const ActiveDescription: React.FC<{
           if (isLocked) return;
           setText(e.target.value);
           destroyRef.current = e.target.value;
-          e.currentTarget.style.height = 'auto';
-          e.currentTarget.style.height = e.currentTarget.scrollHeight + 'px';
+          e.currentTarget.style.height = "auto";
+          e.currentTarget.style.height = e.currentTarget.scrollHeight + "px";
         }}
         value={text}
       />

--- a/packages/editor/src/Graf/Node/components/EditableDefaultValue/index.tsx
+++ b/packages/editor/src/Graf/Node/components/EditableDefaultValue/index.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
-import { fontFamilySans, transition } from '@/vars';
-import styled from '@emotion/styled';
+import React, { useState } from "react";
+import { transition } from "@/vars";
+import styled from "@emotion/styled";
 
 const Input = styled.input`
   border: 0;
   background: ${({ theme }) => theme.neutral[600]}00;
   color: ${({ theme }) => theme.text.default};
   min-width: 18ch;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-size: 12px;
   text-align: left;
   padding: 0.25rem 1rem;
@@ -47,7 +47,7 @@ export const EditableDefaultValue: React.FC<EditableDefaultValueProps> = ({
         onBlur={checkEdit}
         placeholder="Default value"
         onKeyDown={(e) => {
-          if (e.key === 'Enter') {
+          if (e.key === "Enter") {
             checkEdit();
           }
         }}

--- a/packages/editor/src/Graf/Node/components/Menu/Menu.tsx
+++ b/packages/editor/src/Graf/Node/components/Menu/Menu.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 
 import styled from "@emotion/styled";
-import { fontFamilySans } from "@/vars";
 import { motion } from "framer-motion";
 
 const Wrapper = styled(motion.div)`
   width: 220px;
   border-radius: ${(p) => p.theme.radius}px;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   z-index: 2;
 `;
 

--- a/packages/editor/src/Relation/FTUX/BackgroundFTUX.tsx
+++ b/packages/editor/src/Relation/FTUX/BackgroundFTUX.tsx
@@ -59,4 +59,5 @@ const Container = styled(Stack)`
   position: absolute;
   top: 0;
   left: 0;
+  font-family: ${({ theme }) => theme.fontFamilySans};
 `;

--- a/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
+++ b/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { fontFamilySans } from "@/vars";
 import { useTreesState } from "@/state/containers/trees";
 import { useRelationsState } from "@/state/containers";
 import styled from "@emotion/styled";
@@ -140,7 +139,7 @@ const TooltippedZoom = styled.div`
   border: 0;
   text-align: center;
   color: ${({ theme }) => theme.text.default};
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   cursor: pointer;
   border-radius: 4px;
   display: flex;
@@ -152,7 +151,7 @@ const IconWrapper = styled.div`
   font-size: 12px;
   font-weight: 500;
   color: ${({ theme }) => theme.text.disabled};
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   cursor: pointer;
   display: flex;
   user-select: none;
@@ -178,7 +177,7 @@ const ZoomWrapper = styled.div`
 
 const Menu = styled.div`
   display: flex;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   gap: 12px;
   align-items: center;
   position: relative;

--- a/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
+++ b/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
@@ -139,7 +139,6 @@ const TooltippedZoom = styled.div`
   border: 0;
   text-align: center;
   color: ${({ theme }) => theme.text.default};
-  font-family: ${({ theme }) => theme.fontFamilySans};
   cursor: pointer;
   border-radius: 4px;
   display: flex;
@@ -151,7 +150,6 @@ const IconWrapper = styled.div`
   font-size: 12px;
   font-weight: 500;
   color: ${({ theme }) => theme.text.disabled};
-  font-family: ${({ theme }) => theme.fontFamilySans};
   cursor: pointer;
   display: flex;
   user-select: none;
@@ -173,6 +171,7 @@ const ZoomWrapper = styled.div`
   border-width: 1px;
   border-radius: ${(p) => p.theme.radius}px;
   gap: 8px;
+  font-family: ${({ theme }) => theme.fontFamilySans};
 `;
 
 const Menu = styled.div`

--- a/packages/editor/src/Relation/PanZoom/LinesDiagram/LinesDiagram.tsx
+++ b/packages/editor/src/Relation/PanZoom/LinesDiagram/LinesDiagram.tsx
@@ -8,7 +8,6 @@ import React, {
 import { useTreesState } from "@/state/containers/trees";
 import { Node } from "./Node";
 import styled from "@emotion/styled";
-import * as vars from "@/vars";
 import { ParserField, getTypeName } from "graphql-js-tree";
 import { GraphQLEditorWorker, NumberNode } from "graphql-editor-worker";
 import { runAfterFramePaint } from "@/shared/hooks/useMarkFramePaint";
@@ -30,7 +29,7 @@ import {
 const Main = styled.div`
   position: relative;
   overflow-x: visible;
-  font-family: ${vars.fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   align-items: flex-start;
   display: flex;
   padding: 20px;

--- a/packages/editor/src/Relation/PanZoom/LinesDiagram/Node/index.tsx
+++ b/packages/editor/src/Relation/PanZoom/LinesDiagram/Node/index.tsx
@@ -1,7 +1,7 @@
 import { useRelationsState, useTreesState } from "@/state/containers";
 import { getTypeName } from "graphql-js-tree";
 import React, { useMemo, useRef } from "react";
-import { fontFamilySans, transition } from "@/vars";
+import { transition } from "@/vars";
 import styled from "@emotion/styled";
 import { EditorTheme } from "@/gshared/theme/MainTheme";
 import {
@@ -39,7 +39,7 @@ const Content = styled.div<ContentProps>`
   transition: 0.25s all ease-in-out;
   z-index: 1;
   flex: 1 0 auto;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-size: 14px;
   max-width: 66vw;
   visibility: hidden;
@@ -169,7 +169,7 @@ const NameInRelation = styled.span`
   margin-right: 5px;
   color: ${({ theme }) => theme.text.active};
   padding: 0;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
 `;
 
 const EditToSeeWhole = styled(Stack)`

--- a/packages/editor/src/Relation/PanZoom/PanZoom.tsx
+++ b/packages/editor/src/Relation/PanZoom/PanZoom.tsx
@@ -5,7 +5,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { fontFamily, fontFamilySans } from "@/vars";
 import { useTreesState } from "@/state/containers/trees";
 import { useRelationsState } from "@/state/containers";
 import styled from "@emotion/styled";
@@ -300,7 +299,7 @@ const LoadingContainer = styled.div`
   color: ${({ theme }) => theme.text.default};
   background-color: ${({ theme }) => theme.neutral[600]};
   inset: 0;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -311,7 +310,7 @@ const Main = styled.div`
   width: 100%;
   position: relative;
   display: flex;
-  font-family: ${fontFamily};
+  font-family: ${({ theme }) => theme.fontFamily};
   justify-content: flex-end;
   cursor: grab;
 `;

--- a/packages/editor/src/editor/Editor.tsx
+++ b/packages/editor/src/editor/Editor.tsx
@@ -88,6 +88,9 @@ export interface EditorProps extends Pick<CodePaneProps, "onContentChange"> {
   onNodeSelect?: (selectedNodeId?: string) => void;
   // name of the schema file
   path: string;
+  // Editor custom fonts without whole theme needed to be passed
+  fontFamily?: string;
+  fontFamilySans?: string;
 }
 
 export interface ExternalEditorAPI {

--- a/packages/editor/src/editor/code/CodePane.tsx
+++ b/packages/editor/src/editor/code/CodePane.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from "react";
 import { settings } from "./monaco";
-import { fontFamily } from "@/vars";
 import { useErrorsState, useTheme, useTreesState } from "@/state/containers";
 
 import {
@@ -57,7 +56,7 @@ export const CodePane = React.forwardRef<CodePaneApi, CodePaneProps>(
     const codeSettings = useMemo(
       () => ({
         ...settings,
-        fontFamily,
+        fontFamily: theme.fontFamily,
         readOnly: readonly,
       }),
       [readonly]

--- a/packages/editor/src/editor/code/DiffEditorPane.tsx
+++ b/packages/editor/src/editor/code/DiffEditorPane.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { theme as MonacoTheme, diffEditorSettings } from "./monaco";
 
-import { fontFamily } from "@/vars";
 import { useTheme } from "@/state/containers";
 import { SchemaDiffEditor } from "@/editor/code/guild";
 import { CodeContainer } from "@/editor/code/style/Code";
@@ -25,7 +24,7 @@ export const DiffEditorPane = ({ schema, newSchema }: DiffEditorPaneProps) => {
   const codeSettings = useMemo(
     () => ({
       ...diffEditorSettings,
-      fontFamily,
+      fontFamily: theme.fontFamily,
     }),
     []
   );

--- a/packages/editor/src/editor/code/gql/index.tsx
+++ b/packages/editor/src/editor/code/gql/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo } from "react";
-import { fontFamily } from "@/vars";
 import { useErrorsState, useTheme, useTreesState } from "@/state/containers";
 
 import { SchemaEditorApi } from "@/editor/code/guild";
@@ -33,7 +32,7 @@ export const GqlCodePane = (props: GqlCodePaneProps) => {
   const codeSettings = useMemo(
     () => ({
       ...settings,
-      fontFamily,
+      fontFamily: theme.fontFamily,
       readOnly: readonly,
     }),
     [readonly]

--- a/packages/editor/src/editor/code/style/Code.tsx
+++ b/packages/editor/src/editor/code/style/Code.tsx
@@ -1,5 +1,4 @@
-import styled from '@emotion/styled';
-import { fontFamily } from '@/vars';
+import styled from "@emotion/styled";
 
 export const CodeContainer = styled.div`
   flex: 1;
@@ -34,7 +33,7 @@ export const ErrorLock = styled.div`
   background: ${({ theme }) => theme.neutral[600]};
   cursor: pointer;
   color: ${({ theme }) => theme.error};
-  font-family: ${fontFamily};
+  font-family: ${({ theme }) => theme.fontFamily};
   font-size: 14px;
   padding: 30px;
 `;

--- a/packages/editor/src/editor/index.tsx
+++ b/packages/editor/src/editor/index.tsx
@@ -29,6 +29,8 @@ export const GraphQLEditor = React.forwardRef<ExternalEditorAPI, EditorProps>(
     const combinedTheme = {
       ...MainTheme,
       ...baseITheme,
+      ...(props.fontFamily && { fontFamily: props.fontFamily }),
+      ...(props.fontFamilySans && { fontFamilySans: props.fontFamilySans }),
     };
     const theme = props.theme || combinedTheme;
     return (

--- a/packages/editor/src/editor/menu/Menu.tsx
+++ b/packages/editor/src/editor/menu/Menu.tsx
@@ -29,6 +29,7 @@ const Sidebar = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1px;
+  font-family: ${({ theme }) => theme.fontFamilySans};
 `;
 const Filler = styled.div`
   flex: 1;

--- a/packages/editor/src/editor/menu/Menu.tsx
+++ b/packages/editor/src/editor/menu/Menu.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled from "@emotion/styled";
-import { fontFamilySans, transition } from "@/vars";
+import { transition } from "@/vars";
 import {
   Tool,
   Code,
@@ -46,7 +46,7 @@ const MenuItem = styled.div<{
   color: ${({ theme, isDisabled }) =>
     isDisabled ? theme.text.disabled : theme.text.default};
   padding: 1rem;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   cursor: ${({ isDisabled }) => (isDisabled ? "not-allowed" : "pointer")};
   transition: all 0.25s ease;
   overflow: visible;

--- a/packages/editor/src/gshared/theme/MainTheme.ts
+++ b/packages/editor/src/gshared/theme/MainTheme.ts
@@ -1,20 +1,25 @@
-import { ITheme } from '@aexol-studio/styling-system';
+import { ITheme } from "@aexol-studio/styling-system";
 
 export const MainTheme = {
-  base: 'vs-dark',
-  shadow: '#00000022 2px 2px 14px',
+  base: "vs-dark",
+  shadow: "#00000022 2px 2px 14px",
   colors: {
-    type: '#1F8EFE',
-    union: '#8F70FD',
-    input: '#FF8143',
-    scalar: '#4ABB8B',
-    interface: '#D73775',
-    enum: '#A1D835',
-    directive: '#F54747',
-    extend: '#6E7578',
+    type: "#1F8EFE",
+    union: "#8F70FD",
+    input: "#FF8143",
+    scalar: "#4ABB8B",
+    interface: "#D73775",
+    enum: "#A1D835",
+    directive: "#F54747",
+    extend: "#6E7578",
   },
+  fontFamily: `'Fira Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace`,
+  fontFamilySans: `'Fira Sans', 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace`,
 };
 
-export type MainThemeType = typeof MainTheme;
+type MainThemeType = Omit<typeof MainTheme, "fontFamily" | "fontFamilySans"> & {
+  fontFamily?: string;
+  fontFamilySans?: string;
+};
 
 export type EditorTheme = ITheme & MainThemeType;

--- a/packages/editor/src/gshared/theme/MainTheme.ts
+++ b/packages/editor/src/gshared/theme/MainTheme.ts
@@ -17,9 +17,6 @@ export const MainTheme = {
   fontFamilySans: `'Fira Sans', 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace`,
 };
 
-type MainThemeType = Omit<typeof MainTheme, "fontFamily" | "fontFamilySans"> & {
-  fontFamily?: string;
-  fontFamilySans?: string;
-};
+type MainThemeType = typeof MainTheme;
 
 export type EditorTheme = ITheme & MainThemeType;

--- a/packages/editor/src/shared/NodeNavigation/NodeList.tsx
+++ b/packages/editor/src/shared/NodeNavigation/NodeList.tsx
@@ -1,7 +1,7 @@
 import { OperationType, ParserField } from "graphql-js-tree";
 import React from "react";
 import styled from "@emotion/styled";
-import { fontFamilySans, transition } from "@/vars";
+import { transition } from "@/vars";
 import { EditorTheme } from "@/gshared/theme/MainTheme";
 import { ChevronDown } from "@aexol-studio/styling-system";
 import {
@@ -16,7 +16,7 @@ interface TitleProps {
 }
 
 const Title = styled.div<TitleProps>`
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-weight: 600;
   font-size: 14px;
   cursor: ${({ empty }) => (empty ? "auto" : "pointer")};

--- a/packages/editor/src/shared/NodeNavigation/SingleNodeInList.tsx
+++ b/packages/editor/src/shared/NodeNavigation/SingleNodeInList.tsx
@@ -7,7 +7,7 @@ import {
   useRelationNodesState,
   useRelationsState,
 } from "@/state/containers";
-import { fontFamilySans, transition } from "@/vars";
+import { transition } from "@/vars";
 import {
   Link,
   EagleEye,
@@ -332,7 +332,7 @@ const NodeName = styled.div<{
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-size: 14px;
   color: ${({ theme }) => theme.text.default};
   transition: ${transition};

--- a/packages/editor/src/shared/NodeNavigation/index.tsx
+++ b/packages/editor/src/shared/NodeNavigation/index.tsx
@@ -4,7 +4,7 @@ import { useIO, KeyboardActions } from "@/shared/hooks/io";
 import { NodeList, SchemaList } from "@/shared/NodeNavigation/NodeList";
 import { useRelationNodesState, useTreesState } from "@/state/containers";
 import { useSortState } from "@/state/containers/sort";
-import { fontFamilySans, transition } from "@/vars";
+import { transition } from "@/vars";
 import { Eye, EyeSlash, Tooltip } from "@aexol-studio/styling-system";
 import { keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
@@ -64,7 +64,7 @@ const VisibilityBox = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-size: 14px;
   cursor: pointer;
   color: ${({ theme }) => theme.text.disabled};
@@ -80,7 +80,7 @@ const VisibilityBox = styled.div`
 
 const Header = styled.div`
   font-size: 16px;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   font-weight: 500;
   color: ${({ theme }) => theme.text.disabled};
   white-space: nowrap;

--- a/packages/editor/src/shared/components/EditorDialog.tsx
+++ b/packages/editor/src/shared/components/EditorDialog.tsx
@@ -1,14 +1,13 @@
-import { fontFamilySans } from '@/vars';
 import {
   Dialog,
   Typography,
   Stack,
   DialogProps,
-} from '@aexol-studio/styling-system';
-import styled from '@emotion/styled';
-import React from 'react';
+} from "@aexol-studio/styling-system";
+import styled from "@emotion/styled";
+import React from "react";
 export const EditorDialog: React.FC<
-  React.PropsWithChildren<Omit<DialogProps, 'backdrop'> & { title: string }>
+  React.PropsWithChildren<Omit<DialogProps, "backdrop"> & { title: string }>
 > = ({ children, title, ...props }) => {
   return (
     <Dialog backdrop="blur" {...props}>
@@ -30,5 +29,5 @@ const DialogContent = styled.div`
   background-color: ${(p) => p.theme.neutral[600]};
   min-width: 480px;
   padding: 2rem;
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
 `;

--- a/packages/editor/src/shared/components/ErrorLock.tsx
+++ b/packages/editor/src/shared/components/ErrorLock.tsx
@@ -1,6 +1,5 @@
-import { fontFamily } from '@/vars';
-import React from 'react';
-import styled from '@emotion/styled';
+import React from "react";
+import styled from "@emotion/styled";
 
 const Main = styled.div`
   width: 100%;
@@ -13,7 +12,7 @@ const Main = styled.div`
 `;
 
 const Message = styled.textarea`
-  font-family: ${fontFamily};
+  font-family: ${({ theme }) => theme.fontFamily};
   font-size: 14px;
   padding: 30px;
   color: ${({ theme }) => theme.error};

--- a/packages/editor/src/shared/components/Heading.tsx
+++ b/packages/editor/src/shared/components/Heading.tsx
@@ -1,12 +1,11 @@
-import { fontFamilySans } from '@/vars';
-import styled from '@emotion/styled';
-import React from 'react';
+import styled from "@emotion/styled";
+import React from "react";
 
 const StyledHeading = styled.h1`
   font-size: 14px;
   font-weight: 500;
   color: ${({ theme }) => theme.text.disabled};
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
 `;
 
 interface HeadingProps {

--- a/packages/editor/src/shared/errors/ErrorsList.tsx
+++ b/packages/editor/src/shared/errors/ErrorsList.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { fontFamilySans } from "@/vars";
 import styled from "@emotion/styled";
 import {
   ChevronDownDouble,
@@ -9,7 +8,7 @@ import {
 } from "@aexol-studio/styling-system";
 
 export const ErrorWrapper = styled(Stack)`
-  font-family: ${fontFamilySans};
+  font-family: ${({ theme }) => theme.fontFamilySans};
   height: 100%;
   position: absolute;
   top: 0;

--- a/packages/editor/src/vars.tsx
+++ b/packages/editor/src/vars.tsx
@@ -1,6 +1,4 @@
 export const sizeSidebar = 500;
 export const transition = ".25s all ease-out";
-export const fontFamily = `'Fira Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace`;
 export const menuWidth = 46;
 export const maxFieldsInRelationNode = 20;
-export const fontFamilySans = `'Fira Sans', 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace`;

--- a/packages/sandbox/apps/github.tsx
+++ b/packages/sandbox/apps/github.tsx
@@ -25,6 +25,8 @@ export const github = () => {
           setMySchema(props);
         }}
         schema={mySchema}
+        fontFamily="Times New Roman"
+        fontFamilySans="Arial"
       />
     </div>
   );

--- a/packages/sandbox/index.tsx
+++ b/packages/sandbox/index.tsx
@@ -1,13 +1,13 @@
 import { themeColors } from "@aexol-studio/styling-system";
 import styled from "@emotion/styled";
 import { vars } from "graphql-editor";
-import { fontFamilySans } from "graphql-editor/lib/vars";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import * as apps from "./apps";
 import { Global, css } from "@emotion/react";
 
 const MainTheme = themeColors("graphqleditor", "dark");
+const fontFamilySans = `'Times New Roman'`;
 
 export type AppType = keyof typeof apps;
 const Wrapper = styled.div`

--- a/packages/sandbox/index.tsx
+++ b/packages/sandbox/index.tsx
@@ -7,7 +7,7 @@ import * as apps from "./apps";
 import { Global, css } from "@emotion/react";
 
 const MainTheme = themeColors("graphqleditor", "dark");
-const fontFamilySans = `'Times New Roman'`;
+const fontFamilySans = "Arial";
 
 export type AppType = keyof typeof apps;
 const Wrapper = styled.div`


### PR DESCRIPTION
Nie jestem do końca pewna czy o to chodziło, ale:
- przeniosłam fontFamily i fontFamilySans z vars do theme. MainTheme ma domyślnie wartości tych fontow takie jak byly w vars, komponenty css biorą font z theme teraz
- dodalam też dwa opcjonalne propsy fontowe do głównego komponentu edytora pomimo że mamy je teraz w theme, dlatego zeby mozna bylo nadpisac same fonty bez podawania calego theme'u
- czyli opcje sa dwie dodajemy fonty jako string w propsach lub dajemy cały theme z fontami

Nie wiem, czekam na uwagi. Generalnie wydaje mi sie że cel zostal osiągnięty albo go nie zrozumiałam
https://font-as-theme-prop.graphql-editor-dev.pages.dev/
główny widok sandbox ma nadpisany font na arial (znaczy tylko na wraperze), jedna schema "github" ma ustawione fontFamilySans na arial i fontFamily na time new roman w propsach edytora
reszta schem nie ma nic podanego dlatego mają domyślnie Fira Sans i Fira Mono