### PR TITLE
change core definition source

### DIFF
--- a/packages/editor/src/editor/code/guild/editor/utils.ts
+++ b/packages/editor/src/editor/code/guild/editor/utils.ts
@@ -120,7 +120,7 @@ export type DefinitionSource = {
 
 export const coreDefinitionSource: DefinitionSource = {
   forNode: ({ schema, model, token }) => {
-    if (token.state && token.state.kind === "NamedType" && token.state.name) {
+    if (token.state && token.state.kind && token.state.name) {
       const type = schema.getType(token.state.name);
 
       if (type && type.astNode && type.astNode.loc) {


### PR DESCRIPTION
nie ma jakiejś zasady ogólnej kiedy to go to definition nie reaguje w edytorze kodu, ale w schemie przykładowej "github" nie reaguje na typy propertisów z głównej schemy.
Czyli tu nie działa: https://graphql-editor-dev.pages.dev/?a=github
Tu działa: https://go-to-definition.graphql-editor-dev.pages.dev/?a=github

link do issue: https://3.basecamp.com/5657330/buckets/33764929/todos/6524963809