### PR TITLE
Update styling package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13879,6 +13879,14 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-deepmerge": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-6.2.0.tgz",
+      "integrity": "sha512-2qxI/FZVDPbzh63GwWIZYE7daWKtwXZYuyc8YNq0iTmMUwn4mL0jRLsp6hfFlgbdRSR4x2ppe+E86FnvEpN7Nw==",
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "27.1.5",
       "dev": true,
@@ -15347,7 +15355,7 @@
       "license": "MIT",
       "dependencies": {
         "@aexol-studio/hooks": "^0.1.28",
-        "@aexol-studio/styling-system": "^0.1.28",
+        "@aexol-studio/styling-system": "^0.2.6",
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
         "color2k": "^1.2.4",
@@ -15401,13 +15409,16 @@
       }
     },
     "packages/editor/node_modules/@aexol-studio/styling-system": {
-      "version": "0.1.28",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@aexol-studio/styling-system/-/styling-system-0.2.6.tgz",
+      "integrity": "sha512-VwAZLQ+mYBnn6i0IP5XTV1jiWi1vvGj7OGEnVv16whxfCxYAi2+Iuu4wdqUUD0loAcKUUQSYpHYlWtwxUwYJUA==",
       "dependencies": {
         "@aexol-studio/hooks": "*",
-        "country-flag-icons": "^1.5.5",
+        "country-flag-icons": "^1.5.7",
         "framer-motion": "^8.5.2",
         "react-day-picker": "^8.5.0",
         "react-laag": "^2.0.5",
+        "ts-deepmerge": "^6.2.0",
         "unstated-next": "^1.1.0",
         "uuid": "^9.0.0"
       },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@aexol-studio/hooks": "^0.1.28",
-    "@aexol-studio/styling-system": "^0.1.28",
+    "@aexol-studio/styling-system": "^0.2.6",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "color2k": "^1.2.4",

--- a/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
+++ b/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
@@ -57,7 +57,7 @@ export const ControlsBar: React.FC<{
           labelPosition="start"
           onChange={() => setCtrlToZoom(!ctrlToZoom)}
           checked={ctrlToZoom}
-          wrapperCss={{ fontWeight: 400 }}
+          wrapperCss={{ fontWeight: 300 }}
         />
         <ZoomWrapper>
           <IconWrapper
@@ -84,7 +84,7 @@ export const ControlsBar: React.FC<{
             labelPosition="start"
             onChange={() => setLibraryNodesOn(!libraryNodesOn)}
             checked={libraryNodesOn}
-            wrapperCss={{ fontWeight: 400 }}
+            wrapperCss={{ fontWeight: 300 }}
           />
         )}
         <Checkbox
@@ -92,7 +92,7 @@ export const ControlsBar: React.FC<{
           labelPosition="start"
           onChange={() => setFieldsOn(!fieldsOn)}
           checked={fieldsOn}
-          wrapperCss={{ fontWeight: 400 }}
+          wrapperCss={{ fontWeight: 300 }}
         />
         <Checkbox
           label="scalars"
@@ -100,14 +100,14 @@ export const ControlsBar: React.FC<{
           labelPosition="start"
           onChange={() => setBaseTypesOn(!baseTypesOn)}
           checked={fieldsOn ? baseTypesOn : false}
-          wrapperCss={{ fontWeight: 400 }}
+          wrapperCss={{ fontWeight: 300 }}
         />
         <Checkbox
           label="inputs"
           labelPosition="start"
           onChange={() => setInputsOn(!inputsOn)}
           checked={inputsOn}
-          wrapperCss={{ fontWeight: 400 }}
+          wrapperCss={{ fontWeight: 300 }}
         />
         <Tooltip title="Export to png" position="left-bottom">
           <IconWrapper onClick={() => downloadPng()}>

--- a/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
+++ b/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
@@ -187,8 +187,3 @@ const Menu = styled.div`
   position: relative;
   justify-content: flex-end;
 `;
-
-styled(Checkbox)`
-  label {
-  }
-`;

--- a/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
+++ b/packages/editor/src/Relation/PanZoom/ControlsBar.tsx
@@ -57,6 +57,7 @@ export const ControlsBar: React.FC<{
           labelPosition="start"
           onChange={() => setCtrlToZoom(!ctrlToZoom)}
           checked={ctrlToZoom}
+          wrapperCss={{ fontWeight: 400 }}
         />
         <ZoomWrapper>
           <IconWrapper
@@ -83,6 +84,7 @@ export const ControlsBar: React.FC<{
             labelPosition="start"
             onChange={() => setLibraryNodesOn(!libraryNodesOn)}
             checked={libraryNodesOn}
+            wrapperCss={{ fontWeight: 400 }}
           />
         )}
         <Checkbox
@@ -90,6 +92,7 @@ export const ControlsBar: React.FC<{
           labelPosition="start"
           onChange={() => setFieldsOn(!fieldsOn)}
           checked={fieldsOn}
+          wrapperCss={{ fontWeight: 400 }}
         />
         <Checkbox
           label="scalars"
@@ -97,12 +100,14 @@ export const ControlsBar: React.FC<{
           labelPosition="start"
           onChange={() => setBaseTypesOn(!baseTypesOn)}
           checked={fieldsOn ? baseTypesOn : false}
+          wrapperCss={{ fontWeight: 400 }}
         />
         <Checkbox
           label="inputs"
           labelPosition="start"
           onChange={() => setInputsOn(!inputsOn)}
           checked={inputsOn}
+          wrapperCss={{ fontWeight: 400 }}
         />
         <Tooltip title="Export to png" position="left-bottom">
           <IconWrapper onClick={() => downloadPng()}>
@@ -181,4 +186,9 @@ const Menu = styled.div`
   align-items: center;
   position: relative;
   justify-content: flex-end;
+`;
+
+styled(Checkbox)`
+  label {
+  }
 `;

--- a/packages/editor/src/Relation/PanZoom/PanZoom.tsx
+++ b/packages/editor/src/Relation/PanZoom/PanZoom.tsx
@@ -83,6 +83,9 @@ export const PanZoom: React.FC<{
           message:
             "Schema is too big to be printed as a whole. Please focus some nodes or hide part of them before printing.",
           variant: "error",
+          closeMethod: {
+            method: "closeManually",
+          },
         });
         return;
       }

--- a/packages/editor/src/shared/dialogs/ImportSchema.tsx
+++ b/packages/editor/src/shared/dialogs/ImportSchema.tsx
@@ -210,7 +210,7 @@ export const ImportSchema: React.FC<{
             label="Proxy to avoid CORS"
             checked={proxyImport}
             onChange={() => setProxyImport(!proxyImport)}
-            wrapperCss={{ fontWeight: 400 }}
+            wrapperCss={{ fontWeight: 300 }}
           />
           <Typography variant="caption">Headers</Typography>
         </Stack>

--- a/packages/editor/src/shared/dialogs/ImportSchema.tsx
+++ b/packages/editor/src/shared/dialogs/ImportSchema.tsx
@@ -210,6 +210,7 @@ export const ImportSchema: React.FC<{
             label="Proxy to avoid CORS"
             checked={proxyImport}
             onChange={() => setProxyImport(!proxyImport)}
+            wrapperCss={{ fontWeight: 400 }}
           />
           <Typography variant="caption">Headers</Typography>
         </Stack>


### PR DESCRIPTION
Chcialam dodac zeby ten error toast na limit do schemy byl closable z x zeby user mogl na spokojnie przeczytac i zamknac komunikat, ale poprzednia wersja styling systemu tego nie obslugiwala. Po updacie bylo kilka zmian co do typography ale zmienilam tylko font weight dla checkboxow reszta chyba wyglada w miare. moglam zrobic wrapper ale w sumie tych checkboxow nie ma duzo to stwierdzilam ze lepiej kazdy z osobna, ale moge zmienic. 

https://update-styling-package.graphql-editor-dev.pages.dev/?a=Pure