### PR TITLE
distinguish no schema and tree build failure situations

### DIFF
--- a/packages/editor/src/Relation/FTUX/BackgroundFTUX.tsx
+++ b/packages/editor/src/Relation/FTUX/BackgroundFTUX.tsx
@@ -23,7 +23,7 @@ export const BackgroundFTUX = ({
     <Container direction="column" align="center" justify="center" gap="2rem">
       <Stack direction="column" gap="4rem">
         <Stack direction="column" gap="1rem">
-          {!schema.length ? (
+          {!schema ? (
             <Typography>
               Your schema is empty! Please create your first node.
             </Typography>

--- a/packages/editor/src/Relation/FTUX/BackgroundFTUX.tsx
+++ b/packages/editor/src/Relation/FTUX/BackgroundFTUX.tsx
@@ -12,26 +12,36 @@ export const BackgroundFTUX = ({
   onImport,
   onStartCoding,
   showCode,
+  schema,
 }: {
   showCode?: boolean;
   onStartCoding: () => void;
   onImport: () => void;
+  schema: string;
 }) => {
   return (
     <Container direction="column" align="center" justify="center" gap="2rem">
       <Stack direction="column" gap="4rem">
         <Stack direction="column" gap="1rem">
-          <Typography>
-            Your schema is empty! Please create your first node.
-          </Typography>
-          <Stack gap="1rem">
-            {showCode && (
-              <Button onClick={onStartCoding} variant="neutral" size="small">
-                Start coding
-              </Button>
-            )}
-            <NewNode />
-          </Stack>
+          {!schema.length ? (
+            <Typography>
+              Your schema is empty! Please create your first node.
+            </Typography>
+          ) : (
+            <Typography>
+              Cannot parse the schema! Please correct it or create new one.
+            </Typography>
+          )}
+          {!schema && (
+            <Stack gap="1rem">
+              {showCode && (
+                <Button onClick={onStartCoding} variant="neutral" size="small">
+                  Start coding
+                </Button>
+              )}
+              <NewNode />
+            </Stack>
+          )}
         </Stack>
         <Stack direction="column" gap="1rem">
           <Typography>

--- a/packages/editor/src/Relation/Relation.tsx
+++ b/packages/editor/src/Relation/Relation.tsx
@@ -15,8 +15,9 @@ import { ImportSchema } from "@/shared/dialogs/ImportSchema";
 
 export const Relation: React.FC<{
   setInitialSchema: (s: string) => void;
+  schema: string;
   title?: React.ReactNode;
-}> = ({ setInitialSchema, title }) => {
+}> = ({ setInitialSchema, title, schema }) => {
   const { activeNode, focusMode, allNodes } = useTreesState();
   const {
     filteredFocusedNodes,
@@ -109,6 +110,7 @@ export const Relation: React.FC<{
             onImport={() => {
               setPopupsState({ import: true });
             }}
+            schema={schema}
           />
         </AnimatePresence>
       )}

--- a/packages/editor/src/editor/Editor.tsx
+++ b/packages/editor/src/editor/Editor.tsx
@@ -351,6 +351,7 @@ export const Editor = React.forwardRef<ExternalEditorAPI, EditorProps>(
                     source: "outside",
                   })
                 }
+                schema={schema.code}
               />
             )}
             {routes.pane === "docs" && <Docs />}

--- a/packages/editor/src/editor/EmbeddedEditor.tsx
+++ b/packages/editor/src/editor/EmbeddedEditor.tsx
@@ -79,6 +79,7 @@ export const EmbeddedEditor = ({ schema, theme }: EmbeddedEditorProps) => {
           setInitialSchema={(s) => {
             //noop
           }}
+          schema={schema.code}
         />
         <NodeNavigation
           isCollapsed={isCollapsed}


### PR DESCRIPTION
Chodzi o ten problem
https://3.basecamp.com/5657330/buckets/33764929/todos/7397552495

Generalnie mamy dwa stepy przy budowaniu tree, najpierw jest generateTree potem validate. Jesli jest problem na validate to issue nie wystepuje na cloud wersji, czyli tree sie buduje nody sie wyswietlają natomiast jesli zastartujemy projekt ktory bedzie mial error typu `Unexpected <EOF>` to w ogóle drzewo sie nie zbuduje i pokaze nam widok jak przy braku schemy z opcja stworzenia nowego noda itd

Sugeruje rozgraniczenie tych widoków znaczy on teraz pokazuje no schema jak tree.nodes są puste proponuje sprawdzać jeszcze scheme w tym widoku i jak jest schema ale nie da się zbudować tree będzie to tak wyglądalo

![Screenshot 2024-05-22 at 14 36 04](https://github.com/graphql-editor/graphql-editor/assets/27008721/c5dce126-80dc-47f8-8373-84d93fbcd85e)

Jak są inne propozycje dawaj znaka