### PR TITLE
limit supported nodes

### DIFF
--- a/packages/editor/src/Relation/PanZoom/LinesDiagram/LinesDiagram.tsx
+++ b/packages/editor/src/Relation/PanZoom/LinesDiagram/LinesDiagram.tsx
@@ -85,6 +85,7 @@ type LinesDiagramProps = {
   isReadOnly?: boolean;
   parentClass: "focus" | "all";
   setViewportParams: (props: ViewportParams) => void;
+  numberOfSupportedNodes?: number;
 };
 
 export interface LinesDiagramApi {
@@ -103,7 +104,8 @@ export const LinesDiagram = React.forwardRef<
   LinesDiagramApi,
   LinesDiagramProps
 >((props, ref) => {
-  const { nodes, setLoading, mainRef, isReadOnly } = props;
+  const { nodes, setLoading, mainRef, isReadOnly, numberOfSupportedNodes } =
+    props;
   const {
     isLibrary,
     setSelectedNodeId,
@@ -328,12 +330,17 @@ export const LinesDiagram = React.forwardRef<
   const NodesContainer = useMemo(() => {
     return (
       <>
-        {simulatedNodes?.map((n) => (
+        {simulatedNodes?.map((n, index) => (
           <NodePane x={n.x} id={`${n.id}`} y={n.y} key={n.parserField.id}>
             <Node
               isReadOnly={isReadOnly}
               isLibrary={isLibrary(n.parserField)}
               numberNode={n}
+              isDisabled={
+                numberOfSupportedNodes && index > numberOfSupportedNodes
+                  ? true
+                  : false
+              }
             />
           </NodePane>
         ))}

--- a/packages/editor/src/Relation/PanZoom/LinesDiagram/Node/index.tsx
+++ b/packages/editor/src/Relation/PanZoom/LinesDiagram/Node/index.tsx
@@ -119,7 +119,6 @@ const Content = styled.div<ContentProps>`
       font-size: 14px;
     }
   }
-  position: relative;
 `;
 
 const BlurredContent = styled.div`

--- a/packages/editor/src/Relation/PanZoom/LinesDiagram/Node/index.tsx
+++ b/packages/editor/src/Relation/PanZoom/LinesDiagram/Node/index.tsx
@@ -119,6 +119,17 @@ const Content = styled.div<ContentProps>`
       font-size: 14px;
     }
   }
+  position: relative;
+`;
+
+const BlurredContent = styled.div`
+  backdrop-filter: blur(3px);
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  z-index: 10;
 `;
 
 const NodeRelationFields = styled.div<
@@ -209,10 +220,11 @@ interface NodeProps {
   isLibrary?: boolean;
   isReadOnly?: boolean;
   optimized?: boolean;
+  isDisabled?: boolean;
 }
 
 export const Node: React.FC<NodeProps> = (props) => {
-  const { numberNode, isLibrary, isReadOnly } = props;
+  const { numberNode, isLibrary, isReadOnly, isDisabled } = props;
   const { parserField: field } = numberNode;
   const { setSelectedNodeId, focusNode, focusMode, exitFocus } =
     useTreesState();
@@ -273,6 +285,7 @@ export const Node: React.FC<NodeProps> = (props) => {
           <ActiveType type={field.type} />
           {!printPreviewActive && (
             <EditNodeContainer className="editNode">
+              {isDisabled && <BlurredContent />}
               <SmallClickableButton
                 variant="neutral"
                 {...dataIt("nodeFocus")}
@@ -337,6 +350,7 @@ export const Node: React.FC<NodeProps> = (props) => {
       }}
       printPreviewActive={printPreviewActive}
     >
+      {isDisabled && <BlurredContent />}
       {NodeContent}
       {RelationFields}
     </Content>

--- a/packages/editor/src/Relation/PanZoom/PanZoom.tsx
+++ b/packages/editor/src/Relation/PanZoom/PanZoom.tsx
@@ -35,7 +35,8 @@ export const PanZoom: React.FC<{
   hide?: boolean;
   title?: React.ReactNode;
   parentClass: "focus" | "all";
-}> = ({ nodes, hide, parentClass, title }) => {
+  numberOfSupportedNodes?: number;
+}> = ({ nodes, hide, parentClass, title, numberOfSupportedNodes }) => {
   const mainRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const linesRef = useRef<LinesDiagramApi>(null);
@@ -280,6 +281,7 @@ export const PanZoom: React.FC<{
         setLoading={(e) => {
           setLargeSimulationLoading(e);
         }}
+        numberOfSupportedNodes={numberOfSupportedNodes}
       />
     );
   }, [

--- a/packages/editor/src/Relation/Relation.tsx
+++ b/packages/editor/src/Relation/Relation.tsx
@@ -17,7 +17,8 @@ export const Relation: React.FC<{
   setInitialSchema: (s: string) => void;
   schema: string;
   title?: React.ReactNode;
-}> = ({ setInitialSchema, title, schema }) => {
+  numberOfSupportedNodes?: number;
+}> = ({ setInitialSchema, title, schema, numberOfSupportedNodes }) => {
   const { activeNode, focusMode, allNodes } = useTreesState();
   const {
     filteredFocusedNodes,
@@ -56,6 +57,7 @@ export const Relation: React.FC<{
             parentClass="all"
             nodes={filteredRelationNodes}
             title={title}
+            numberOfSupportedNodes={numberOfSupportedNodes}
           />
         </TransformWrapper>
       </>
@@ -85,6 +87,7 @@ export const Relation: React.FC<{
                   title={title}
                   parentClass="focus"
                   nodes={nodesToShow}
+                  numberOfSupportedNodes={numberOfSupportedNodes}
                 />
               </TransformWrapper>
             </FocusOverlay>

--- a/packages/editor/src/editor/Editor.tsx
+++ b/packages/editor/src/editor/Editor.tsx
@@ -110,6 +110,8 @@ export interface EditorProps
   fontFamilySans?: string;
   disableExport?: boolean;
   disableImport?: boolean;
+  // Enter number of supported nodes for schema, rest would be blurred and disabled
+  numberOfSupportedNodes?: number;
 }
 
 export interface ExternalEditorAPI {
@@ -141,6 +143,7 @@ export const Editor = React.forwardRef<ExternalEditorAPI, EditorProps>(
       disableImport,
       onEditorMount,
       leafs,
+      numberOfSupportedNodes,
     },
     ref
   ) => {
@@ -377,6 +380,7 @@ export const Editor = React.forwardRef<ExternalEditorAPI, EditorProps>(
                     schema={schema}
                     fullScreen={!routes.pane}
                     readonly={readonly}
+                    numberOfSupportedNodes={numberOfSupportedNodes}
                   />
                 </Sidebar>
               </DynamicResize>
@@ -394,6 +398,7 @@ export const Editor = React.forwardRef<ExternalEditorAPI, EditorProps>(
                       })
                     }
                     schema={schema.code}
+                    numberOfSupportedNodes={numberOfSupportedNodes}
                   />
                 )}
                 {routes.pane === "docs" && <Docs />}

--- a/packages/editor/src/editor/code/CodePane.tsx
+++ b/packages/editor/src/editor/code/CodePane.tsx
@@ -28,6 +28,7 @@ import type * as monaco from "monaco-editor";
 
 export interface CodePaneOuterProps {
   readonly?: boolean;
+  numberOfSupportedNodes?: number;
 }
 
 export type CodePaneProps = Pick<LiveSchemaEditorProps, "onContentChange"> & {
@@ -41,11 +42,12 @@ export type CodePaneProps = Pick<LiveSchemaEditorProps, "onContentChange"> & {
 export type CodePaneApi = Pick<LiveSchemaEditorApi, "receive">;
 
 /**
- * React compontent holding GraphQL IDE
+ * React component holding GraphQL IDE
  */
 export const CodePane = React.forwardRef<CodePaneApi, CodePaneProps>(
   (props, ref) => {
-    const { schema, readonly, onChange, fullScreen } = props;
+    const { schema, readonly, onChange, fullScreen, numberOfSupportedNodes } =
+      props;
     const { theme } = useTheme();
     const { selectedNodeId, setSelectedNodeId, allNodes } = useTreesState();
     const { errorRowNumber } = useErrorsState();
@@ -60,8 +62,9 @@ export const CodePane = React.forwardRef<CodePaneApi, CodePaneProps>(
         ...settings,
         fontFamily: theme.fontFamily,
         readOnly: readonly,
+        contextmenu: !numberOfSupportedNodes,
       }),
-      [readonly]
+      [readonly, numberOfSupportedNodes]
     );
 
     useEffect(() => {
@@ -156,6 +159,7 @@ export const CodePane = React.forwardRef<CodePaneApi, CodePaneProps>(
             schema={schema}
             options={codeSettings}
             select={selectFunction}
+            numberOfSupportedNodes={numberOfSupportedNodes}
           />
         )}
       </CodeContainer>

--- a/packages/editor/src/editor/code/guild/editor/LiveSchemaEditor.tsx
+++ b/packages/editor/src/editor/code/guild/editor/LiveSchemaEditor.tsx
@@ -21,6 +21,7 @@ export type LiveSchemaEditorProps = SchemaServicesOptions & {
     sdl: string,
     languageService: EnrichedLanguageService
   ) => void;
+  numberOfSupportedNodes?: number;
 } & Omit<EditorProps, "language">;
 
 export type LiveSchemaEditorApi = SchemaEditorApi & {
@@ -94,6 +95,17 @@ function BaseSchemaEditor(
       onMount={(editor, monaco) => {
         setEditor(editor);
         props.onMount && props.onMount(editor, monaco);
+        if (props.numberOfSupportedNodes) {
+          editor.onKeyDown((event) => {
+            const { keyCode, ctrlKey, metaKey } = event;
+            if (
+              (keyCode === 33 || keyCode === 52 || keyCode === 54) &&
+              (metaKey || ctrlKey)
+            ) {
+              event.preventDefault();
+            }
+          });
+        }
       }}
       keepCurrentModel
       onChange={(newValue, ev) => {

--- a/packages/sandbox/apps/index.tsx
+++ b/packages/sandbox/apps/index.tsx
@@ -20,3 +20,4 @@ export * from "./VeryLongSchema";
 export * from "./livesocket";
 export * from "./exoticDirectives";
 export * from "./justcode";
+export * from "./limitSupportedNodes";

--- a/packages/sandbox/apps/limitSupportedNodes.tsx
+++ b/packages/sandbox/apps/limitSupportedNodes.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { PassedSchema, GraphQLEditor } from "graphql-editor";
 import * as schemas from "../schema";
 
-export const withSchema = () => {
+export const limitSupportedNodes = () => {
   const [mySchema, setMySchema] = useState<PassedSchema>({
     code: schemas.billabeeSchema,
     libraries: "",
@@ -25,10 +25,11 @@ export const withSchema = () => {
           setMySchema(props);
         }}
         schema={mySchema}
-        numberOfSupportedNodes={10}
+        numberOfSupportedNodes={20}
       />
     </div>
   );
 };
 
-withSchema.description = "Part schema of a big delivery service Deliverer.";
+limitSupportedNodes.description =
+  "Part schema of a big delivery service Deliverer with limited supported number of Nodes";


### PR DESCRIPTION
https://limit-supported-nodes.graphql-editor-dev.pages.dev/?a=limitSupportedNodes

n pierwszych nodów jest pokazanych normalnie (w przykładzie 20) reszta blurred (nie można na nich akcji wykonać) w code pane jest zablokowane command pallete i copy/paste/cut z klawiatury. Nody poza tym wszystkie mozna modyfikowac w monaco edytorze? nie wiem czy jest możliwe blokowanie edycji wybiórczo.

informacja dlaczego chyba z poziomy desktopa? Po prostu przy wybraniu większej schemy raz pokazana więc tu nic nie dodaje do handlingu takiego